### PR TITLE
Support GHC 9.0 & test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,13 @@ jobs:
           - "8.6.5"
           - "8.8.4"
           - "8.10.2"
+          - "9.0.1"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-haskell@v1
       with:
-        cabal-version: "3.2"
+        cabal-version: "3.4"
         ghc-version: ${{ matrix.ghc-version }}
     - name: Cache
       uses: actions/cache@v1

--- a/union.cabal
+++ b/union.cabal
@@ -37,7 +37,7 @@ library
                        RankNTypes
                        ScopedTypeVariables
                        TypeOperators
-  build-depends:       base >=4.9 && <4.15
+  build-depends:       base >=4.9 && <4.17
                ,       vinyl >=0.5 && <0.14
                ,       profunctors >=5.1 && <5.7
                ,       tagged >=0.8 && <0.9


### PR DESCRIPTION
Like before, no changes required. There's a StarIsType warning I could fix if you'd like (not sure if I could import Type for all GHC 8.2 and newer, or if it necessitates CPP).