### PR TITLE
support GHC 9.2, 9.4; update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,19 @@ jobs:
     strategy:
       matrix:
         ghc-version:
-          - "8.2.2"
-          - "8.4.4"
+          # GHC 8.2, 8.4: https://github.com/VinylRecords/Vinyl/pull/168
+          # - "8.2.2" # new vinyl doesn't support
+          # - "8.4.4" # new vinyl broke support
           - "8.6.5"
           - "8.8.4"
-          - "8.10.2"
-          - "9.0.1"
+          - "8.10.7"
+          - "9.0.2"
+          - "9.2.4"
+          - "9.4.2"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-haskell@v1
+    - uses: haskell/actions/setup@v2
       with:
         cabal-version: "3.4"
         ghc-version: ${{ matrix.ghc-version }}

--- a/union.cabal
+++ b/union.cabal
@@ -37,8 +37,8 @@ library
                        RankNTypes
                        ScopedTypeVariables
                        TypeOperators
-  build-depends:       base >=4.9 && <4.17
-               ,       vinyl >=0.5 && <0.14
+  build-depends:       base >=4.9 && <4.18
+               ,       vinyl >= 0.14.3 && <0.15
                ,       profunctors >=5.1 && <5.7
                ,       tagged >=0.8 && <0.9
                ,       deepseq >=1.4 && <1.5


### PR DESCRIPTION
Vinyl lower bound has to be bumped due to a recent GHC 9.2 fix.

union currently tests from GHC 8.2 onwards. Turns out Vinyl broke GHC 8.4 support in a recent release, and GHC 8.2 isn't supported either. So this PR drops support for those. I don't see any reasons not to support them, so I made a PR here: https://github.com/VinylRecords/Vinyl/pull/168 . If the old support matters, this PR should perhaps wait until that one is resolved.