### PR TITLE
Support GHC 9.6, 9.8, maybe 9.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
           - "9.0.2"
           - "9.2.4"
           - "9.4.2"
+          - "9.6.4"
+          - "9.8.2"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/union.cabal
+++ b/union.cabal
@@ -37,12 +37,12 @@ library
                        RankNTypes
                        ScopedTypeVariables
                        TypeOperators
-  build-depends:       base >=4.9 && <4.18
+  build-depends:       base >=4.9 && <4.21
                ,       vinyl >= 0.14.3 && <0.15
                ,       profunctors >=5.1 && <5.7
                ,       tagged >=0.8 && <0.9
-               ,       deepseq >=1.4 && <1.5
-               ,       hashable >=1.2 && <1.5
+               ,       deepseq >=1.4 && <1.7
+               ,       hashable >=1.2 && <1.6
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall


### PR DESCRIPTION
Bumped `base` upper bound. Also bumped all dependency upper bounds to their newest version. (I haven't tested all of those newest versions due to my distribution not providing them.)

My GHC 9.6 and 9.8 build without issue. Also added them to CI. Not tested GHC 9.10 (not easy to use on Nix yet).

No code changes.